### PR TITLE
[EMX] Update material resistivities

### DIFF
--- a/emx/aureo.proc
+++ b/emx/aureo.proc
@@ -38,12 +38,12 @@ define VIASOI1LOWMETAL1 = SOI1*LOWMETAL1
 
 layer 1000 1.0 1 # Air
 layer 85 1.0 1 1e12 ohm-cm
-  conductor 40.0 10.0 ohm-cm SOI1
+  conductor 40.0 5846 ohm/sq SOI1
   offset 40.0
   offset 0.001
   conductor 0.999 2.44e-8 ohm-cm LOWMETAL1
   offset 0.499
-  conductor 1.0 1.0 ohm-cm POLY1
+  conductor 1.0 229.14 ohm/sq POLY1
   offset 1.0
   offset 0.001
   conductor 0.998 2.44e-8 ohm-cm HIGHMETAL1
@@ -51,15 +51,17 @@ layer 85 1.0 1 1e12 ohm-cm
   offset 0.001
   conductor 0.998 2.44e-8 ohm-cm HIGHMETAL2
   offset 0.999
-  conductor 1.0 1.0 ohm-cm POLY2
+  conductor 1.0 229.14 ohm/sq POLY2
   offset 0.5
   conductor 0.999 2.44e-8 ohm-cm LOWMETAL2
   offset 0.5
   offset 0.5
-  conductor 40.0 10.0 ohm-cm SOI2
+  conductor 40.0 5846 ohm/sq SOI2
 layer infinity 1.0
 
-via SOI1 POLY1 10 ohm-cm NITRIDE1
+# Update the nitride layers' resistivity after it has been measured.
+# 1e15 ohm-cm causes EMX to output an incorrect result, possibly due to precision.
+via SOI1 POLY1 1e9 ohm-cm NITRIDE1
 via SOI1 LOWMETAL1 2.44e-8 ohm-cm VIASOI1LOWMETAL1
 via LOWMETAL1 HIGHMETAL1 2.44e-8 ohm-cm VIALOWMETAL1HIGHMETAL1
 via POLY1 HIGHMETAL1 2.44e-8 ohm-cm VIAPOLY1HIGHMETAL1
@@ -67,4 +69,4 @@ via HIGHMETAL1 HIGHMETAL2 2.44e-8 ohm-cm VIAHIGHMETAL1HIGHMETAL2
 via HIGHMETAL2 POLY2 2.44e-8 ohm-cm VIAHIGHMETAL2POLY2
 via HIGHMETAL2 LOWMETAL2 2.44e-8 ohm-cm VIAHIGHMETAL2LOWMETAL2
 via LOWMETAL2 SOI2 2.44e-8 ohm-cm VIALOWMETAL2SOI2
-via POLY2 SOI2 10 ohm-cm NITRIDE2
+via POLY2 SOI2 1e9 ohm-cm NITRIDE2


### PR DESCRIPTION
This PR updates the Aureo layer resistivities to the latest measured values by @lyichen5958.
<img width="1130" alt="aureo_properties" src="https://github.com/user-attachments/assets/d464f266-5a2d-4589-90f2-2fe92a358ed4">

EMX allows for (1) loss tangents to be included in the stackup definitions and (2) frequency-dependent parameters, and these are TODOs for more realistic simulation results.  Currently, the results seem overly optimistic (see second screenshot below).
<img width="1140" alt="aureo_sim" src="https://github.com/user-attachments/assets/6b41c6ef-31de-4b1b-9765-5b5b1abb1641">
